### PR TITLE
Use dns over tcp for UpCloud machines

### DIFF
--- a/conf/upcloud.yml
+++ b/conf/upcloud.yml
@@ -65,6 +65,13 @@
         state: present
       notify: restart sshd
 
+    # This circumvents DNS UPD issue: https://github.com/wunderkraut/WunderTools/issues/197
+    - name: Use TCP for dns requests
+      lineinfile:
+        dest: /etc/resolv.conf
+        line: "options use-vc"
+        state: present
+
   handlers:
     - name: restart sshd
       service:


### PR DESCRIPTION
~Fixes #197~. This doesn't fix anything but according to http://www.vinc17.net/unix/resolv.en.html makes retrying dns queries faster.