### PR TITLE
Refactor cron and add drupal_web_root variable

### DIFF
--- a/conf/develop.yml
+++ b/conf/develop.yml
@@ -19,11 +19,35 @@
   - dev-vars.yml
 
   tasks:
-  # Drupal cron job
-  - cron: name="Example Drupal cron job" minute="*/2" job="su nginx --shell=/bin/sh -c '/usr/lib/composer/vendor/bin/drush --root=/var/www/example.com/current/web cron > /dev/null 2>&1'" state="present"
+    # Disable email from cron
+    - name: "Disable emails from failed cronjobs for nginx user"
+      cron:
+        name: "MAILTO"
+        env: yes
+        value: ""
+        state: "present"
+        user: nginx
+      tags: ['cron']
+    # Run Drupal cron job
+    - name: "Add drupal cronjob to nginx user"
+      cron:
+        name: "Run Drupal cronjobs with drush"
+        minute: "*/2"
+        job: "/usr/lib/composer/vendor/bin/drush --root={{ drupal_web_root }} cron"
+        state: "present"
+        user: nginx
+      tags: ['cron']
+      when: drupal_web_root is defined
 
   vars:
     wkv_site_env: dev
+
+    # You can set custom variables if the same value is used in multiple places so it can be easily changed here
+    # You can use it anywhere after this using " {{ variable_name }}"
+    domain_name: develop.example.com
+
+    # This is used in cronjob and varnish and nginx configs
+    drupal_web_root: "/var/www/{{ domain_name }}/current/web"
 
     # How to assign memory for each role and set the correct
     # memory_app and memory_db define how much total system memory is allocated to each.
@@ -36,9 +60,9 @@
 
     # Apps I want to run on this server
     apps:
-      - server_name: dev.example.com
+      - server_name: "{{ domain_name }}"
         http_port: 8080
-        docroot: /var/www/example.com/current/web
+        docroot: "{{ drupal_web_root }}"
 
     # This server also acts as a load balancer
     varnish:
@@ -46,7 +70,7 @@
       memory: 512M
       directors:
         - name: example
-          host: dev.example.com
+          host: "{{ domain_name }}"
           backends:
             - name: example_http
               address: 127.0.0.1

--- a/conf/prod-front.yml
+++ b/conf/prod-front.yml
@@ -17,7 +17,7 @@
    - { role: newrelic-infra, tags: [ 'newrelic-infra' ] }
 
 
- 
+
   tasks:
     # Disable email from cron
     - name: "Disable emails from failed cronjobs for nginx user"

--- a/conf/prod-front.yml
+++ b/conf/prod-front.yml
@@ -17,7 +17,7 @@
    - { role: newrelic-infra, tags: [ 'newrelic-infra' ] }
 
 
-  
+ 
   tasks:
     # Disable email from cron
     - name: "Disable emails from failed cronjobs for nginx user"

--- a/conf/prod-front.yml
+++ b/conf/prod-front.yml
@@ -17,15 +17,37 @@
    - { role: newrelic-infra, tags: [ 'newrelic-infra' ] }
 
 
-
+  
   tasks:
+    # Disable email from cron
+    - name: "Disable emails from failed cronjobs for nginx user"
+      cron:
+        name: "MAILTO"
+        env: yes
+        value: ""
+        state: "present"
+        user: nginx
+      tags: ['cron']
 
-    # Set drupal cron to be run every minute alternately on both servers
-    - cron: name="Example Drupal cron job" minute="*/2" job="su nginx --shell=/bin/sh -c '/usr/lib/composer/vendor/bin/drush --root=/var/www/example.com/current elysia-cron run > /dev/null 2>&1'" state="present"
-      when: ansible_eth0.ipv4.address == groups['wundertools-prod-front'][0]
-
-    - cron: name="Example Drupal cron job" minute="1-59/2" job="su nginx --shell=/bin/sh -c '/usr/lib/composer/vendor/bin/drush --root=/var/www/example.com/current elysia-cron run > /dev/null 2>&1'" state="present"
-      when: ansible_eth0.ipv4.address == groups['wundertools-prod-front'][1]
+    # Set drupal cron to be run every minute and alternate between both servers
+    - name: "Run drupal cronjob with nginx user at even minutes"
+      cron:
+        name: "Run Drupal cronjobs with drush"
+        minute: "*/2"
+        job: "/usr/lib/composer/vendor/bin/drush --root={{ drupal_web_root }} elysia-cron run"
+        state: "present"
+        user: nginx
+      tags: ['cron']
+      when: ansible_eth0.ipv4.address == groups['wundertools-prod-front'][0] and drupal_web_root is defined
+    - name: "Run drupal cronjob with nginx user at odd minutes"
+      cron:
+        name: "Run Drupal cronjobs with drush"
+        minute: "1-59/2"
+        job: "/usr/lib/composer/vendor/bin/drush --root={{ drupal_web_root }} elysia-cron run"
+        state: "present"
+        user: nginx
+      tags: ['cron']
+      when: ansible_eth0.ipv4.address == groups['wundertools-prod-front'][1] and drupal_web_root is defined
 
   vars:
 
@@ -43,12 +65,12 @@
         server_aliases: "{{ domain1_name }}"
         server_forwards: "{{ domain1_name }}"  # we redirect to www subdomain
         http_port: 8080
-        docroot: /var/www/prod1/current
-      - server_name: "www.{{ domain2_name }}"
-        server_aliases: "{{ domain2_name }}"
-        server_forwards: "{{ domain2_name }}"  # we redirect to www subdomain
-        http_port: 8080
-        docroot: /var/www/prod2/current/web # This is D8 site!
+        docroot: "{{ drupal_web_root }}"
+      #- server_name: "www.{{ domain2_name }}"
+      #  server_aliases: "{{ domain2_name }}"
+      #  server_forwards: "{{ domain2_name }}"  # we redirect to www subdomain
+      #  http_port: 8080
+      #  docroot: /var/www/prod2/current/web # This is D8 site!
 
     # You can also define aliases with app_dir_aliases, see ansible/playbook/roles/nginx/templates/all_apps.conf.j2
 

--- a/conf/production.yml
+++ b/conf/production.yml
@@ -28,7 +28,7 @@
     # This server hosts multiple domains
     domain1_name: example1.com
     domain2_name: example2.com
-    
+
     # This is D8 web root with atomic builds
     # This variable is used for nginx and cronjobs
     drupal_web_root: "/var/www/{{ domain1_name }}/current/web"

--- a/conf/production.yml
+++ b/conf/production.yml
@@ -28,6 +28,10 @@
     # This server hosts multiple domains
     domain1_name: example1.com
     domain2_name: example2.com
+    
+    # This is D8 web root with atomic builds
+    # This variable is used for nginx and cronjobs
+    drupal_web_root: "/var/www/{{ domain1_name }}/current/web"
 
     ## Base ##
 

--- a/conf/stage.yml
+++ b/conf/stage.yml
@@ -24,8 +24,25 @@
   - stage-vars.yml
 
   tasks:
-  # Drupal cron job
-  - cron: name="Example Drupal cron job" minute="*/2" job="su nginx --shell=/bin/sh -c '/usr/lib/composer/vendor/bin/drush --root=/var/www/example.com/current elysia-cron run > /dev/null 2>&1'" state="present"
+    # Disable email from cron
+    - name: "Disable emails from failed cronjobs for nginx user"
+      cron:
+        name: "MAILTO"
+        env: yes
+        value: ""
+        state: "present"
+        user: nginx
+      tags: ['cron']
+    # Run Drupal cron job
+    - name: "Add drupal cronjob to nginx user"
+      cron:
+        name: "Run Drupal cronjobs with drush"
+        minute: "*/2"
+        job: "/usr/lib/composer/vendor/bin/drush --root={{ drupal_web_root }} cron"
+        state: "present"
+        user: nginx
+      tags: ['cron']
+      when: drupal_web_root is defined
 
   vars:
     wkv_site_env: stage
@@ -33,6 +50,9 @@
     # You can set custom variables if the same value is used in multiple places so it can be easily changed here
     # You can use it anywhere after this using " {{ variable_name }}"
     domain_name: stage.example.com
+
+    # This is used in cronjob and varnish and nginx configs
+    drupal_web_root: "/var/www/{{ domain_name }}/current/web"
 
     partition_var_log: False
     partition_var_lib_mysql: False
@@ -69,7 +89,7 @@
     apps:
       - server_name: "{{ domain_name }}"
         http_port: 8080
-        docroot: /var/www/example.com/current/web
+        docroot: "{{ drupal_web_root }}"
 
     create_docroot: True
 


### PR DESCRIPTION
This adds example cronjobs which really work even on the first run.

I also refactored the cronjobs to use nginx user without the ugly `su nginx ...` oneliner and used `MAILTO=""` instead of redirecting everything to `/dev/null`.