### PR TITLE
Remove elysia-cron and use 'drupal cron' as default cronjob command

### DIFF
--- a/conf/prod-front.yml
+++ b/conf/prod-front.yml
@@ -34,7 +34,7 @@
       cron:
         name: "Run Drupal cronjobs with drush"
         minute: "*/2"
-        job: "/usr/lib/composer/vendor/bin/drush --root={{ drupal_web_root }} elysia-cron run"
+        job: "/usr/lib/composer/vendor/bin/drush --root={{ drupal_web_root }} cron"
         state: "present"
         user: nginx
       tags: ['cron']
@@ -43,7 +43,7 @@
       cron:
         name: "Run Drupal cronjobs with drush"
         minute: "1-59/2"
-        job: "/usr/lib/composer/vendor/bin/drush --root={{ drupal_web_root }} elysia-cron run"
+        job: "/usr/lib/composer/vendor/bin/drush --root={{ drupal_web_root }} cron"
         state: "present"
         user: nginx
       tags: ['cron']


### PR DESCRIPTION
@floretan mentioned that `elysia-cron` is not used for d8 sites so I would want our default configuration to be working out of the box.