### PR TITLE
Fix fatal failure due to missing variable.

### DIFF
--- a/conf/vagrant.yml
+++ b/conf/vagrant.yml
@@ -113,3 +113,7 @@
         forwarded_domains: '"{{ domain_name }}"'
 
     php_env_vars_include_db: True
+
+    # These variables need to be defined even if we don't use them locally.
+    base_pubkeys_enable: False
+    base_pubkeys_host: key.server.tld


### PR DESCRIPTION
Without the `base_pubkeys_host` variable, we get the following error:

```
[default]: FAILED! => {"changed": false, "failed": true, "msg": "AnsibleUndefinedVariable: https://{{ base_pubkeys_host }}/auth?hostname={{ ansible_nodename }}: 'base_pubkeys_host' is undefined"}
```