### PR TITLE
Avoid over-allocating heap for elasticsearch on vagrant.

### DIFF
--- a/conf/vagrant.yml
+++ b/conf/vagrant.yml
@@ -114,3 +114,6 @@
         forwarded_domains: '"{{ domain_name }}"'
 
     php_env_vars_include_db: True
+
+    # Set a low heap allocation for Elasticsearch on vagrant.
+    elasticsearch_heap_size: 200m


### PR DESCRIPTION
The default heap allocation for elasticsearch (2G) is good for production but too large for vagrant environments. 

The configuration only applies when the Elasticsearch role is enabled, but it doesn't interfere otherwise. 