### PR TITLE
20170918 - Cache sanitised dump on target.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ test/composer.lock
 test/vendor
 test/bin
 VERSION
+drupal/SYNCDIR
+drupal/syncdb


### PR DESCRIPTION
This PR adds caching to target environment by default. The stored "cache" dump is sanitised. This makes consecutive syncs 3/4 faster. Syncing is done to the project folder which makes the first uncached local vagrant sync 1/4 faster since we don't have to rsync to target environment from local. This PR also adds -r flag for reloading the cache and -fra for reverting features during the sync. Final touch is a graceful cancelling of the sync before the target database is dropped if the user so chooses.

Tested on a project.

Fixes #229. Also fixes #107 by providing -h flag.