### PR TITLE
Replace deprecated webflo/drush-shim package with drush/drush-launcher.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
 install:
   - cd $TRAVIS_BUILD_DIR/drupal
   - composer install -n --ignore-platform-reqs
-  - composer global require webflo/drush-shim
+  - composer global require drush/drush-launcher
 
   # Build frontend code, adjust these commands to your code.
   # - cd $TRAVIS_BUILD_DIR/drupal/web/themes/custom/*


### PR DESCRIPTION
It seems that webflo/drush-shim sources has been removed from GitHub. In PHP package page it says: 

> "This package is abandoned and no longer maintained. The author suggests using the drush/drush-launcher package instead."

Thus proposing that we replace webflo/drush-shim with drush/drush-launcher in .travis.yml