### PR TITLE
Modify the default settings so that if patches cannot be applied the composer install step fails.

### DIFF
--- a/drupal/composer.json
+++ b/drupal/composer.json
@@ -69,6 +69,7 @@
             "web/themes/contrib/{$name}": ["type:drupal-theme"],
             "drush/contrib/{$name}": ["type:drupal-drush"]
         },
+        "composer-exit-on-patch-failure": true,
         "dropin-paths": {
             "web/": ["type:web-dropin"]
         },


### PR DESCRIPTION
As found on the readme of the "composer-patches" package, the default behaviour is that a patch cannot be applied the build is allowed to continue.  As a default, I think that it's not a useful behaviour to have, so I propose to set this setting to "TRUE" so that if patching fails the build is not allowed to go through.

More info on the readme of the package at: https://github.com/cweagans/composer-patches#error-handling