### PR TITLE
Add --uri to cron runs.

### DIFF
--- a/conf/prod-front.yml
+++ b/conf/prod-front.yml
@@ -36,7 +36,7 @@
       cron:
         name: "Run Drupal cronjobs with drush"
         minute: "*/2"
-        job: "/usr/lib/composer/vendor/bin/drush --root={{ drupal_web_root }} cron"
+        job: "/usr/lib/composer/vendor/bin/drush --root={{ drupal_web_root }} --uri={{ domain2_name }} cron"
         state: "present"
         user: nginx
       tags: ['cron']
@@ -45,7 +45,7 @@
       cron:
         name: "Run Drupal cronjobs with drush"
         minute: "1-59/2"
-        job: "/usr/lib/composer/vendor/bin/drush --root={{ drupal_web_root }} cron"
+        job: "/usr/lib/composer/vendor/bin/drush --root={{ drupal_web_root }} --uri={{ domain2_name }} cron"
         state: "present"
         user: nginx
       tags: ['cron']


### PR DESCRIPTION
Resolves #269 
I used domain2_name as that is usually the actual production domain name while domain1_name is usually internal dns name.