### PR TITLE
Show rule names in the phpcs report.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ script:
 
   # Check coding standards
   - cd $TRAVIS_BUILD_DIR/drupal
-  - phpcs --standard=phpcs.xml
+  - phpcs --standard=phpcs.xml -s
 
   # Run a clean Drupal installation
   - cd $TRAVIS_BUILD_DIR/drupal/web


### PR DESCRIPTION
When phpcs throws an error, it's useful to know the rule that was triggered. For examples, for longstanding projects it's often risky to rename all variables just for the sake of style guide compliance, and it's easier to exclude `Drupal.NamingConventions.ValidVariableName` from phpcs.xml. Adding the `-s` parameter makes this easier (it took me many days of working with phpcs before I realized this option existed). 