### PR TITLE
Option "--no-interaction" is added to "composer install" command

### DIFF
--- a/drupal/build.sh
+++ b/drupal/build.sh
@@ -191,6 +191,7 @@ class Maker:
         # Do not install dev packages on non-development environments
         if self.site_env != 'default' and self.site_env != 'local':
             params.append('--no-dev')
+            params.append('--no-interaction')
 
         self._composer([
             '-d=' + self.temp_build_dir,


### PR DESCRIPTION
This change adds `--no-interaction` option to `composer install` command on
non-development environments to prevent command line prompts on deployments. Default action as to whether changes need to be discarded can be defined in `composer.json` file with `discard-changes` option set to `true`, `false` or `stash`.

See also:
- Docs on global options - https://getcomposer.org/doc/03-cli.md#global-options
- Docs on "discard-changes" option - https://getcomposer.org/doc/06-config.md#discard-changes

This PR fixes https://github.com/wunderio/WunderTools/issues/273