### PR TITLE
Property "discard-changes" is set to "true" by default in composer.json

### DIFF
--- a/drupal/composer.json
+++ b/drupal/composer.json
@@ -38,6 +38,9 @@
     "conflict": {
         "drupal/drupal": "*"
     },
+    "config": {
+        "discard-changes": true
+    },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "autoload": {


### PR DESCRIPTION
This will discard all modifications if composer is run in non-interactive mode.

See docs for `discard-changes` property: https://getcomposer.org/doc/06-config.md#discard-changes.