### PR TITLE
Switch to using drush9 and drush-launcher by default.

### DIFF
--- a/conf/variables.yml
+++ b/conf/variables.yml
@@ -28,10 +28,10 @@ partition_var_lib_mysql: False
 php_package: "php71u"
 
 drush: {
-  version: "8.*",
+  version: "9.*",
 }
 
-drush_use_launcher: False
+drush_use_launcher: True
 php_env_vars_include_db: True
 expose_php_vars_globally: True
 

--- a/drupal/composer.json
+++ b/drupal/composer.json
@@ -21,7 +21,7 @@
         "drupal-composer/drupal-scaffold": "^2.2",
         "drupal/console": "^1.0.2",
         "drupal/core": "~8.4",
-        "drush/drush": "~8.0|^9.0.0-beta8",
+        "drush/drush": "~9.1",
         "webflo/drupal-finder": "^1.0.0",
         "webmozart/path-util": "^2.3",
         "drupal/config_installer": "~1.0",


### PR DESCRIPTION
Now that we have environment variables global by default we can switch using drush 9 and drush-launhcer by default. 