### PR TITLE
Elasticsearch 5.5 added to .lando.yml file as a service

### DIFF
--- a/drupal/.lando.yml
+++ b/drupal/.lando.yml
@@ -43,12 +43,16 @@ services:
           DB_HOST_DRUPAL: database
           DB_NAME_DRUPAL: drupal8
 
+  elasticsearch:
+    type: elasticsearch:5.5
+
 proxy:
   mailhog:
     - mail.lndo.site
+  elasticsearch:
+    - elasticsearch.lndo.site:9200
 
 events:
   # Clear caches after a database import
   post-db-import:
     - appserver: cd $LANDO_WEBROOT && drush cr -y
-


### PR DESCRIPTION
This change adds Elasticsearch 5.5 as a service.

Steps to review:
1. Run `lando start`
2. Open http://elasticsearch.lndo.site and see that default Elasticsearch greeting is displayed:

```
{
  "name" : "yMBNLqH",
  "cluster_name" : "elasticsearch",
  "cluster_uuid" : "D3VwL4RlSzCZ7OoTEnsRJw",
  "version" : {
    "number" : "5.5.2",
    "build_hash" : "b2f0c09",
    "build_date" : "2017-08-14T12:33:14.154Z",
    "build_snapshot" : false,
    "lucene_version" : "6.6.0"
  },
  "tagline" : "You Know, for Search"
}
```