### PR TITLE
Elasticsearch service is defined as optional (not enabled by default)

### DIFF
--- a/drupal/.lando.yml
+++ b/drupal/.lando.yml
@@ -43,14 +43,16 @@ services:
           DB_HOST_DRUPAL: database
           DB_NAME_DRUPAL: drupal8
 
-  elasticsearch:
-    type: elasticsearch:5.5
+  # Optional. Uncomment the following lines if Elasticsearch is required.
+  # elasticsearch:
+  #   type: elasticsearch:5.5
 
 proxy:
   mailhog:
     - mail.lndo.site
-  elasticsearch:
-    - elasticsearch.lndo.site:9200
+  # Optional. Uncomment the following lines if Elasticsearch is required.
+  # elasticsearch:
+  #   - elasticsearch.lndo.site:9200
 
 events:
   # Clear caches after a database import


### PR DESCRIPTION
This is a follow-up PR of https://github.com/wunderio/WunderTools/pull/291 which makes Elasticsearch service optional (not enabled by default).