### PR TITLE
Load db credentials from the Lando environment variable.

### DIFF
--- a/drupal/web/sites/default/settings.php
+++ b/drupal/web/sites/default/settings.php
@@ -20,6 +20,19 @@ $databases['default']['default'] = [
   'driver' => 'mysql',
 ];
 
+// Load database credentials from Lando.
+if (getenv('LANDO_INFO')) {
+  $lando_info = json_decode(getenv('LANDO_INFO'), TRUE);
+  $databases['default']['default'] = [
+    'driver' => 'mysql',
+    'database' => $lando_info['database']['creds']['database'],
+    'username' => $lando_info['database']['creds']['user'],
+    'password' => $lando_info['database']['creds']['password'],
+    'host' => $lando_info['database']['internal_connection']['host'],
+    'port' => $lando_info['database']['internal_connection']['port'],
+  ];
+}
+
 // CHANGE THIS.
 $settings['hash_salt'] = 'some-hash-salt-please-change-this';
 


### PR DESCRIPTION
Lando updated the way it provides db credentials, this is needed to work with newer versions.