### PR TITLE
Include imagemagick by default in composer.json.

### DIFF
--- a/drupal/composer.json
+++ b/drupal/composer.json
@@ -27,7 +27,8 @@
         "drupal/config_installer": "~1.0",
         "drupal/warden": "*",
         "drupal/simplei": "^1.0",
-        "wunderio/drupal-ping": "^1.0"
+        "wunderio/drupal-ping": "^1.0",
+        "drupal/imagemagick": "^2.3"
     },
     "require-dev": {
         "codeception/codeception": "^2.2",


### PR DESCRIPTION
We already have GraphicsMagick installed on all servers by default and it's way more memory efficient than GD. Devs just need to remember to enable and configure it.