### PR TITLE
WKHTMLTOPDF setup template for Lando

### DIFF
--- a/drupal/.lando.yml
+++ b/drupal/.lando.yml
@@ -34,6 +34,11 @@ services:
     extras:
       - "apt-get update -y"
       - "apt-get install python-yaml -y"
+      # wkhtmltopdf setup
+      # - "[ -f /usr/bin/wkhtmltopdf ] || ( apt-get update -y && apt-get install xvfb )"
+      # - "[ -f /usr/bin/wkhtmltopdf ] || ( wget -nc https://downloads.wkhtmltopdf.org/0.12/0.12.5/wkhtmltox_0.12.5-1.jessie_amd64.deb -P /tmp )"
+      # - "[ -e /usr/bin/wkhtmltopdf ] || ( dpkg -i /tmp/wkhtmltox_0.12.5-1.jessie_amd64.deb )"
+      # - "[ -f /usr/bin/wkhtmltopdf ] || ( ln -s /usr/local/bin/wkhtmltopdf /usr/bin/wkhtmltopdf )"
     overrides:
       services:
         environment:


### PR DESCRIPTION
We needed a wkhtmltopdf for our project, here's what we came up with. Could have used the vagrant role compile method, but using deb from [wkhtmltopdf documentation](https://github.com/wkhtmltopdf/wkhtmltopdf/blob/master/docs/downloads.md) seemed so much more convinient since we're using Debian on lando.

Also, there's a check, so that it doesn't re-run the whole thing every time lando is stared. ` apt-get update + install python-yaml` could use something similar to speed up the boot process.

Sources:
- https://github.com/lando/lando/pull/573
- https://github.com/lando/lando/issues/572