### PR TITLE
Configure the simpleindicator module for local development with lando.

### DIFF
--- a/drupal/web/sites/default/settings.php
+++ b/drupal/web/sites/default/settings.php
@@ -100,6 +100,7 @@ switch ($env) {
     break;
 
   case 'local':
+  case 'lando':
     $settings['simple_environment_indicator'] = '#88b700 Local';
     break;
 }


### PR DESCRIPTION
The `WKV_SITE_ENV` environment variable is set to "lando" when using lando, so this should be added to settings.php.