### PR TITLE
Update phpcs.xml to support Coder 8.x-3.x

### DIFF
--- a/drupal/phpcs.xml
+++ b/drupal/phpcs.xml
@@ -25,7 +25,7 @@
         <exclude name="Drupal.Commenting.DocComment" />
         <exclude name="Drupal.Commenting.FunctionComment" />
         <exclude name="Drupal.Commenting.InlineComment" />
-        <exclude name="Drupal.Array.Array" />
+        <exclude name="Drupal.Arrays.Array" />
         <exclude name="Drupal.Files.TxtFileLineLength" />
         <exclude name="PEAR.Commenting.ClassComment" />
     </rule>


### PR DESCRIPTION
This PR updates phpcs.xml to support new Drupal Coder 8.x-3.x.

Coder is used in out Travis CI configuration. New Coder version adds support for PHP_CodeSniffer 3.x. (as PHP_CodeSniffer 2.x has been deprecated)

For reason unknown, `Drupal.Array.Array` rule was updated to `Drupal.Arrays.Array `and thus, phpcs.xml file needs to updated accordingly.