### PR TITLE
Define memcache settings only if memcache module enabled

### DIFF
--- a/drupal/web/sites/default/settings.php
+++ b/drupal/web/sites/default/settings.php
@@ -110,38 +110,40 @@ $config_directories = array(
   CONFIG_SYNC_DIRECTORY => '../sync',
 );
 
-if (class_exists('Memcached')) {
-  /**
-   * Memcache configuration.
-   */
-  $settings['memcache']['extension'] = 'Memcached';
-  $settings['memcache']['bins'] = ['default' => 'default'];
-  $settings['memcache']['key_prefix'] = '';
-  #$settings['cache']['default'] = 'cache.backend.memcache';
-  $settings['cache']['bins']['render'] = 'cache.backend.memcache';
-  $settings['cache']['bins']['dynamic_page_cache'] = 'cache.backend.memcache';
-  $settings['cache']['bins']['bootstrap'] = 'cache.backend.memcache';
-  $settings['cache']['bins']['config'] = 'cache.backend.memcache';
-  $settings['cache']['bins']['discovery'] = 'cache.backend.memcache';
+/**
+ * Memcache configuration.
+ */
+if (!drupal_installation_attempted() && extension_loaded('memcached') && class_exists('Memcached')) {
+  // Define memcache settings only if memcache module enabled.
+  if (class_exists(MemcacheBackendFactory::class)) {
+    $settings['memcache']['extension'] = 'Memcached';
+    $settings['memcache']['bins'] = ['default' => 'default'];
+    $settings['memcache']['key_prefix'] = '';
+    #$settings['cache']['default'] = 'cache.backend.memcache';
+    $settings['cache']['bins']['render'] = 'cache.backend.memcache';
+    $settings['cache']['bins']['dynamic_page_cache'] = 'cache.backend.memcache';
+    $settings['cache']['bins']['bootstrap'] = 'cache.backend.memcache';
+    $settings['cache']['bins']['config'] = 'cache.backend.memcache';
+    $settings['cache']['bins']['discovery'] = 'cache.backend.memcache';
 
-  // Enable stampede protection.
-  $settings['memcache']['stampede_protection'] = TRUE;
+    // Enable stampede protection.
+    $settings['memcache']['stampede_protection'] = TRUE;
 
-  // High performance - no hook_boot(), no hook_exit(), ignores Drupal IP
-  // blacklists.
-  $conf['page_cache_invoke_hooks'] = FALSE;
-  $conf['page_cache_without_database'] = TRUE;
+    // High performance - no hook_boot(), no hook_exit(), ignores Drupal IP
+    // blacklists.
+    $conf['page_cache_invoke_hooks'] = FALSE;
+    $conf['page_cache_without_database'] = TRUE;
 
-  // Memcached PECL Extension Support.
-  // Adds Memcache binary protocol and no-delay features (experimental).
-  $settings['memcache']['options'] = [
-    \Memcached::OPT_COMPRESSION => FALSE,
-    \Memcached::OPT_DISTRIBUTION => \Memcached::DISTRIBUTION_CONSISTENT,
-    \Memcached::OPT_BINARY_PROTOCOL => TRUE,
-    \Memcached::OPT_TCP_NODELAY => TRUE,
-  ];
+    // Memcached PECL Extension Support.
+    // Adds Memcache binary protocol and no-delay features (experimental).
+    $settings['memcache']['options'] = [
+      \Memcached::OPT_COMPRESSION => FALSE,
+      \Memcached::OPT_DISTRIBUTION => \Memcached::DISTRIBUTION_CONSISTENT,
+      \Memcached::OPT_BINARY_PROTOCOL => TRUE,
+      \Memcached::OPT_TCP_NODELAY => TRUE,
+    ];
+  }
 }
-
 
 /**
  * Access control for update.php script.


### PR DESCRIPTION
This PR adds additional checks to memcache configuration to ensure that settings are applied only if 

- Drupal installation is not currently being attempted (and memcached service is running and php-pecl-memcache**d** extension enabled), AND
- Memcache contrib module installed and enabled in Drupal installation


(Travis CI checks will fail due to erroneous phpcs.xml for Coder 8.x-3.x, see PR #301) 