### PR TITLE
Exclude CSS files from phpcs

### DIFF
--- a/drupal/phpcs.xml
+++ b/drupal/phpcs.xml
@@ -20,6 +20,9 @@
     <!-- exclude third-party node modules -->
     <exclude-pattern>node_modules/</exclude-pattern>
 
+    <!-- exclude CSS files, where we don't usually follow Drupal standards  -->
+    <exclude-pattern>*.css</exclude-pattern>
+
     <rule ref="Drupal">
         <exclude name="Drupal.Commenting.FileComment" />
         <exclude name="Drupal.Commenting.DocComment" />


### PR DESCRIPTION
Based on the recent discussion in slack, since we don't usually follow the Drupal coding standards for CSS files, we might as well exclude them from our phpcs configuration by default.