### PR TITLE
Clear caches before config-imports

### DIFF
--- a/drupal/conf/site.yml
+++ b/drupal/conf/site.yml
@@ -43,6 +43,7 @@ default:
           - builds
       - make
       - drush: updb -y
+      - drush: cr
       - drush: cim -y
       - cleanup
       - shell:
@@ -98,6 +99,7 @@ test:
 
     update:
       - drush: updb -y
+      - drush: cr
       - drush: cim -y
       - cleanup
       - shell: chmod -R a-w web
@@ -141,6 +143,7 @@ production:
 
     update:
       - drush: updb -y
+      - drush: cr
       - drush: cim -y
       - cleanup
       - shell: chmod -R a-w web


### PR DESCRIPTION
Builds fail if new plugin(s) are introduced that the updated configurations try to use.

Clear caches before config-import to be sure all changes are registered.