### PR TITLE
Update lando mariadb to 10.2

### DIFF
--- a/drupal/.lando.yml
+++ b/drupal/.lando.yml
@@ -8,7 +8,7 @@ config:
   webroot: web
   via: nginx
   php: '7.1'
-  database: mariadb:10.1
+  database: mariadb:10.2
   #xdebug: true
 
 tooling:
@@ -23,12 +23,12 @@ tooling:
     cmd:
     - ./vendor/bin/codecept
 
-services:  
+services:
   mailhog:
     type: mailhog
     hogfrom:
       - appserver
-  
+
   appserver:
     extras:
       - "apt-get update -y"
@@ -67,4 +67,3 @@ events:
   post-start:
     - appserver: mkdir -p $LANDO_MOUNT/.drush/site-aliases
     - appserver: ln -sf /app/drush/wundertools.aliases.drushrc.php $LANDO_MOUNT/.drush/site-aliases/wundertools.aliases.drushrc.php
-    


### PR DESCRIPTION
Reason I am suggesting this `mariadb:10.1` fails on a client project to 
```Specified key was too long; max key length is 767 bytes```
when importing dev/stage/prod and mariadb 10.2 clearly fixes this by defaulting to innodb. And don't we use 10.2 on most new environments anyway?

My VSC auto-fixed the empty spaces..