### PR TITLE
Use vendor and package name as package name to comply with composer 2.0

### DIFF
--- a/drupal/composer.json
+++ b/drupal/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "Wundertools Drupal 8",
+    "name": "wunderio/wundertools",
     "description": "Wundertools Drupal 8 Composer Project Template",
     "type": "project",
     "license": "GPL-2.0+",


### PR DESCRIPTION
As per composer notice:

> Deprecation warning: Your package name Wundertools Drupal 8 is invalid, it should have a vendor name, a forward slash, and a package name. The vendor and package name can be words separated by -, . or _. The complete name should match "[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9]([_.-]?[a-z0-9]+)*". Make sure you fix this as Composer 2.0 will error.