### PR TITLE
Skip node_modules folder from being scanned.

### DIFF
--- a/drupal/web/sites/default/settings.php
+++ b/drupal/web/sites/default/settings.php
@@ -140,6 +140,21 @@ $settings['update_free_access'] = FALSE;
 $settings['container_yamls'][] = __DIR__ . '/services.yml';
 
 /**
+ * The default list of directories that will be ignored by Drupal's file API.
+ *
+ * By default ignore node_modules and bower_components folders to avoid issues
+ * with common frontend tools and recursive scanning of directories looking for
+ * extensions.
+ *
+ * @see file_scan_directory()
+ * @see \Drupal\Core\Extension\ExtensionDiscovery::scanDirectory()
+ */
+$settings['file_scan_ignore_directories'] = [
+  'node_modules',
+  'bower_components',
+];
+
+/**
  * Environment specific override configuration, if available.
  */
 if (file_exists(__DIR__ . '/settings.local.php')) {


### PR DESCRIPTION
The default settings file coming from Drupal (default.settings.php) includes configuration to skip the scanning of `node_modules`, which can typically be very large and is not relevant to Drupal. This can particularly become an issue while developing locally where filesystem access is slow (the usual problem with both Lando and Vagrant). If we don't specify this explicitly in settings.php, the default is to skip nothing. 

We'll need to follow up on individual projects as well to make sure this gets added.