### PR TITLE
Add a dependabot configuration in code

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,10 @@
+version: 1
+
+update_configs:
+  - package_manager: "php:composer"
+    directory: "/drupal"
+    update_schedule: "live"
+
+  - package_manager: "javascript"
+    directory: "/drupal"
+    update_schedule: "live"


### PR DESCRIPTION
Currently dependabot needs to be enabled and configured for all new projects. Now that dependabot supports configuration in code (see https://dependabot.com/blog/introducing-config-files/), we can add a default configuration to this repository so new projects are configured by default.