### PR TITLE
Update Lando to 3.0.0-RC.2+. Fixes #325, temp. fixes #324.

### DIFF
--- a/drupal/.lando.yml
+++ b/drupal/.lando.yml
@@ -1,9 +1,6 @@
 name: wunderlando
 recipe: drupal8
 
-compose:
-  - compose.yml
-
 config:
   webroot: web
   via: nginx
@@ -30,16 +27,18 @@ services:
       - appserver
 
   appserver:
-    extras:
-      - "apt-get update -y"
-      - "apt-get install python-yaml -y"
+    build:
+      # Perform composer install.
+      - composer install
+      # build_as_root:
+      # - "apt-get update -y"
+      # - "apt-get install python-yaml -y"
       # wkhtmltopdf setup
       # - "[ -f /usr/bin/wkhtmltopdf ] || ( apt-get update -y && apt-get install xvfb -y)"
       # - "[ -f /usr/bin/wkhtmltopdf ] || ( wget -nc https://downloads.wkhtmltopdf.org/0.12/0.12.5/wkhtmltox_0.12.5-1.jessie_amd64.deb -P /tmp )"
       # - "[ -e /usr/bin/wkhtmltopdf ] || ( dpkg -i /tmp/wkhtmltox_0.12.5-1.jessie_amd64.deb )"
       # - "[ -f /usr/bin/wkhtmltopdf ] || ( ln -s /usr/local/bin/wkhtmltopdf /usr/bin/wkhtmltopdf )"
     overrides:
-      services:
         environment:
           WKV_SITE_ENV: lando
           DB_PASS_DRUPAL: drupal8
@@ -47,6 +46,18 @@ services:
           DB_HOST_DRUPAL: database
           DB_NAME_DRUPAL: drupal8
           SITE_URL: 'https://nginx'
+          HASH_SALT: notsosecurehash
+  # Optional. Uncomment the following lines to enable chrome service.
+  # chrome:
+  #   type: compose
+  #   services:
+  #     image: selenium/standalone-chrome
+  #     user: root
+  #     ports:
+  #       - "4444:4444"
+  #     volumes:
+  #       - /dev/shm:/dev/shm
+  #     command: /opt/bin/entry_point.sh
 
   # Optional. Uncomment the following lines if Elasticsearch is required.
   # elasticsearch:

--- a/drupal/compose.yml
+++ b/drupal/compose.yml
@@ -1,8 +1,0 @@
-version: '2'
-services:
-  chrome:
-    image: selenium/standalone-chrome
-    volumes:
-      - /dev/shm:/dev/shm
-    ports:
-      - "4444:4444"

--- a/drupal/web/sites/default/settings.lando.php
+++ b/drupal/web/sites/default/settings.lando.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * Load database credentials from Lando app environment.
+ */
+$lando_info = json_decode(getenv('LANDO_INFO'), TRUE);
+$databases['default']['default'] = [
+  'driver' => 'mysql',
+  'database' => $lando_info['database']['creds']['database'],
+  'username' => $lando_info['database']['creds']['user'],
+  'password' => $lando_info['database']['creds']['password'],
+  'host' => $lando_info['database']['internal_connection']['host'],
+  'port' => $lando_info['database']['internal_connection']['port'],
+];
+
+// Use the hash_salt setting from Lando.
+$settings['hash_salt'] = getenv('HASH_SALT');
+
+// Skip file system permissions hardening when using local development with Lando.
+$settings['skip_permissions_hardening'] = TRUE;
+
+// Skip trusted host pattern when using Lando.
+$settings['trusted_host_patterns'] = ['.*'];

--- a/drupal/web/sites/default/settings.php
+++ b/drupal/web/sites/default/settings.php
@@ -23,21 +23,6 @@ $databases['default']['default'] = [
 // CHANGE THIS.
 $settings['hash_salt'] = 'some-hash-salt-please-change-this';
 
-if (getenv('LANDO_INFO')) {
-  /*
-   * Load database credentials from Lando.
-   */
-  $lando_info = json_decode(getenv('LANDO_INFO'), TRUE);
-  $databases['default']['default'] = [
-    'driver' => 'mysql',
-    'database' => $lando_info['database']['creds']['database'],
-    'username' => $lando_info['database']['creds']['user'],
-    'password' => $lando_info['database']['creds']['password'],
-    'host' => $lando_info['database']['internal_connection']['host'],
-    'port' => $lando_info['database']['internal_connection']['port'],
-  ];
-}
-
 if ((isset($_SERVER["HTTPS"]) && strtolower($_SERVER["HTTPS"]) == "on")
   || (isset($_SERVER["HTTP_X_FORWARDED_PROTO"]) && $_SERVER["HTTP_X_FORWARDED_PROTO"] == "https")
   || (isset($_SERVER["HTTP_HTTPS"]) && $_SERVER["HTTP_HTTPS"] == "on")
@@ -144,6 +129,13 @@ $settings['container_yamls'][] = __DIR__ . '/services.yml';
  */
 if (file_exists(__DIR__ . '/settings.local.php')) {
   include __DIR__ . '/settings.local.php';
+}
+
+/**
+ * Lando configuration overrides.
+ */
+if (getenv('LANDO_INFO') && file_exists($app_root . '/' . $site_path . '/settings.lando.php')) {
+  include $app_root . '/' . $site_path . '/settings.lando.php';
 }
 
 /**


### PR DESCRIPTION
Steps to update to Lando 3.0.0-RC.2+:

1. `lando db-export` - export your local database
2. `lando destroy`
3. `lando poweroff`
4. apply changes in this PR
5. delete `~/.lando` folder
6. `lando start`
7. `lando db-import { dump created in a step 1. }`

Update docs: https://docs.devwithlando.io/guides/updating-to-rc2.html

This PR uses work from wunderio/drupal-project/pull/39 + additional changes.

NB! Drush aliases doesn't work because of #326.