### PR TITLE
Fix/aa minor fixes after lando update

### DIFF
--- a/drupal/.lando.yml
+++ b/drupal/.lando.yml
@@ -39,14 +39,14 @@ services:
       # - "[ -e /usr/bin/wkhtmltopdf ] || ( dpkg -i /tmp/wkhtmltox_0.12.5-1.jessie_amd64.deb )"
       # - "[ -f /usr/bin/wkhtmltopdf ] || ( ln -s /usr/local/bin/wkhtmltopdf /usr/bin/wkhtmltopdf )"
     overrides:
-        environment:
-          WKV_SITE_ENV: lando
-          DB_PASS_DRUPAL: drupal8
-          DB_USER_DRUPAL: drupal8
-          DB_HOST_DRUPAL: database
-          DB_NAME_DRUPAL: drupal8
-          SITE_URL: 'https://nginx'
-          HASH_SALT: notsosecurehash
+      environment:
+        WKV_SITE_ENV: lando
+        DB_PASS_DRUPAL: drupal8
+        DB_USER_DRUPAL: drupal8
+        DB_HOST_DRUPAL: database
+        DB_NAME_DRUPAL: drupal8
+        SITE_URL: 'https://nginx'
+        HASH_SALT: notsosecurehash
   # Optional. Uncomment the following lines to enable chrome service.
   # chrome:
   #   type: compose


### PR DESCRIPTION
fixed indentation in .lando.yml
fixed settings.lando.php: getting database settings from lando info env (lando_info is a list, not a hash - taking service info by servie key does not make any sense)