### PR TITLE
Use php 7.2 by default.

### DIFF
--- a/drupal/.lando.yml
+++ b/drupal/.lando.yml
@@ -4,7 +4,7 @@ recipe: drupal8
 config:
   webroot: web
   via: nginx
-  php: '7.1'
+  php: '7.2'
   database: mariadb:10.2
   #xdebug: true
 

--- a/drupal/.lando.yml
+++ b/drupal/.lando.yml
@@ -30,9 +30,9 @@ services:
     build:
       # Perform composer install.
       - composer install
-      # build_as_root:
-      # - "apt-get update -y"
-      # - "apt-get install python-yaml -y"
+    build_as_root:
+      - "apt-get update -y"
+      - "apt-get install python-yaml -y"
       # wkhtmltopdf setup
       # - "[ -f /usr/bin/wkhtmltopdf ] || ( apt-get update -y && apt-get install xvfb -y)"
       # - "[ -f /usr/bin/wkhtmltopdf ] || ( wget -nc https://downloads.wkhtmltopdf.org/0.12/0.12.5/wkhtmltox_0.12.5-1.jessie_amd64.deb -P /tmp )"


### PR DESCRIPTION
The lando image that gets loaded when php 7.1 is selected points to a debian repository which has been deprecated. Also, as php 7.1 is reaching end of life it's a natural move to stop using it.