### PR TITLE
Remove features documentation

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -1,5 +1,0 @@
-Features
-========
-
-Write info about the features you are using and what they hold. This will help people keeping them in good shape and debug them when something's missing.
-

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -3,7 +3,6 @@
 [Information Architecture](information_architecture.md)
 [Theme](theme.md)
 [Modules](modules.md)
-[Features](features.md)
 [Views](views.md)
 [Hacks](hacks.md)
 [Continuous integration](continuous-integration.md)


### PR DESCRIPTION
We don't use features for Drupal 8 anymore, so no need for a dedicated doc file.