### PR TITLE
Remove outdated example and fix application root

### DIFF
--- a/drupal/silta/nginx.Dockerfile
+++ b/drupal/silta/nginx.Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for building nginx.
 FROM wunderio/drupal-nginx:v0.1
 
-COPY . /var/www/html/web
+COPY . /app/web
 

--- a/drupal/silta/php.Dockerfile
+++ b/drupal/silta/php.Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for the Drupal container.
 FROM wunderio/drupal-php-fpm:v0.1
 
-COPY --chown=www-data:www-data . /var/www/html
+COPY --chown=www-data:www-data . /app
 

--- a/drupal/silta/shell.Dockerfile
+++ b/drupal/silta/shell.Dockerfile
@@ -1,4 +1,4 @@
 # Dockerfile for the Drupal container.
 FROM wunderio/drupal-shell:v0.1
 
-COPY --chown=www-data:www-data . /var/www/html
+COPY --chown=www-data:www-data . /app

--- a/drupal/silta/silta.yml
+++ b/drupal/silta/silta.yml
@@ -1,9 +1,6 @@
 
 # Values in this file override the default values of our helm chart.
 #
-# See https://github.com/wunderio/charts/blob/master/drupal/README.md
+# See https://github.com/wunderio/charts/blob/master/drupal/values.yaml
 # for all possible options.
 
-# Example: enable private files for Drupal.
-#privateFiles:
-#  enabled: true


### PR DESCRIPTION
The way volumes are specified in silta.yml is now more flexible, and the given example
does not work anymore. See https://github.com/wunderio/charts/blob/master/drupal/values.yaml 
for an example of adding a volume for private files.

The application root within the container is now /app, it is more consistent across different 
types of applications and is also commonly used by other container-based hosting providers.

This pull request was created with https://github.com/wunderio/internal-mass-updater.