### PR TITLE
Set the location of the Drupal config files in silta setup as defined in settings.php

### DIFF
--- a/drupal/silta/silta.yml
+++ b/drupal/silta/silta.yml
@@ -4,3 +4,8 @@
 # See https://github.com/wunderio/charts/blob/master/drupal/values.yaml
 # for all possible options.
 
+# Configuration for everything that runs in php containers.
+php:
+  # Define the location of the Drupal config files relative to the composer root.
+  # This variable is exposed as $DRUPAL_CONFIG_PATH in the container.
+  drupalConfigPath: "sync"


### PR DESCRIPTION
This PR updates the location of the Drupal config files in silta setup to be equal as defined in settings.php.

By default, settings.php defines config file directory to be in `sync` (relative to the composer root) , wheras default location of the Drupal config files in silta setup are in `config/sync`. `sync`folder is also included in source code of WunderTools.

(Alternative we should change config file directory in settings.php to be `config/sync` as in silta setup and move `sync` folder to `config/sync` in the source code)