### PR TITLE
Lock the Python version to v3.6, fixes #378.

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -1,7 +1,7 @@
 name: provision
 services:
   python:
-    type: python:3.7
+    type: python:3.6
     build_as_root:
       - "apt-get update -y"
       # Resolve the locale language issue.
@@ -12,7 +12,7 @@ services:
       - git clone git@github.com:wunderio/WunderMachina.git --branch master --single-branch ansible
       - install -d -m 777 /var/www/.local/share
       - cd /app/ansible && pip install pipenv
-      - cd /app/ansible && pipenv install
+      - cd /app/ansible && pipenv install --python 3.6
     overrides:
       environment:
         # Set the path to the Ansible vault file. Save the password to the `~/.ssh/ansible.vault` file.

--- a/provision.sh
+++ b/provision.sh
@@ -25,7 +25,7 @@ function parse_yaml {
 
 show_help() {
 cat <<EOF
-Usage: ${0##*/} [-fm MYSQL_ROOT_PASS] [-t|s ANSIBLE_TAGS] [-p ANSIBLE_VAULT_FILE] [ENVIRONMENT] 
+Usage: ${0##*/} [-fm MYSQL_ROOT_PASS] [-t|s ANSIBLE_TAGS] [-p ANSIBLE_VAULT_FILE] [ENVIRONMENT]
       -f                    First run, use when provisioning new servers.
       -r                    Skip installing requirements from ansible/requirements.txt.
       -m MYSQL_ROOT_PASS    For first run you need to provide new mysql root password.
@@ -188,9 +188,9 @@ if [ ! $SKIP_REQUIREMENTS ] ; then
 
     # Ensure ansible & ansible library versions with pip
     if [ -f $ROOT/ansible/Pipfile.lock ]; then
-      pipenv install 
+      pipenv install --python 3.6
     else
-      pipenv install ansible
+      pipenv install ansible --python 3.6
     fi
   fi
 fi


### PR DESCRIPTION
WunderTools needs Python version max `3.6` to work. We're hardcoding the version both in `lando.yml` & `provision.sh` to make sure it's working properly.

## Testing

Run `lando rebuild` locally and verify that the following message is present at the end:

```
...
Creating a virtualenv for this project...
Pipfile: /app/ansible/Pipfile
Using /usr/local/bin/python3.6m (3.6.15) to create virtualenv...
⠧ Creating virtual environment...created virtual environment CPython3.6.15.final.0-64 in 434ms
  creator CPython3Posix(dest=/root/.local/share/virtualenvs/ansible-2NGQgKTl, clear=False, no_vcs_ignore=False, global=False)
  seeder FromAppData(download=False, pip=bundle, setuptools=bundle, wheel=bundle, via=copy, app_data_dir=/root/.local/share/virtualenv)
    added seed packages: pip==21.3.1, setuptools==59.6.0, wheel==0.37.1
  activators BashActivator,CShellActivator,FishActivator,NushellActivator,PowerShellActivator,PythonActivator

✔ Successfully created virtual environment! 
```